### PR TITLE
Fix correct waypoints type to be nullish

### DIFF
--- a/src/directive/agm-direction.directive.ts
+++ b/src/directive/agm-direction.directive.ts
@@ -37,7 +37,7 @@ export class AgmDirection implements OnChanges, OnInit, OnDestroy {
   @Input() markerOptions: {
     origin: google.maps.MarkerOptions,
     destination: google.maps.MarkerOptions,
-    waypoints: google.maps.MarkerOptions,
+    waypoints?: google.maps.MarkerOptions,
   };
 
   @Input() infoWindow: google.maps.InfoWindow;
@@ -245,8 +245,8 @@ export class AgmDirection implements OnChanges, OnInit, OnDestroy {
 
                       // If waypoints are not array then set all the same
                       if (!Array.isArray(this.markerOptions.waypoints)) {
-                        this.markerOptions.waypoints.map = map;
-                        this.markerOptions.waypoints.position = _route.via_waypoints[index];
+                        this.markerOptions.waypoints!.map = map;
+                        this.markerOptions.waypoints!.position = _route.via_waypoints[index];
                         this.waypointsMarker.push(this.setMarker(
                           map,
                           waypoint,


### PR DESCRIPTION
I was getting build errors saying 

    Property 'waypoints' is missing in type '{ origin: MarkerOptions; destination: MarkerOptions; }' but required in type '{ origin: 
    MarkerOptions; destination: MarkerOptions; waypoints: MarkerOptions; }'.
    
After checking the docs and the types of the library I found a mismatch.

Library types:

    markerOptions: {
          origin: google.maps.MarkerOptions;
          destination: google.maps.MarkerOptions;
          waypoints: google.maps.MarkerOptions;
    };

While in the [docs](https://developers.google.com/maps/documentation/javascript/directions)

> waypoints[] (optional) specifies an array of DirectionsWaypoints. Waypoints alter a route by routing it through the specified location(s). A waypoint is specified as an object literal with fields shown below:

so I just added a question mark to the type.

so now it is:

    markerOptions: {
          origin: google.maps.MarkerOptions;
          destination: google.maps.MarkerOptions;
          waypoints**?**: google.maps.MarkerOptions;
    };
